### PR TITLE
Add Multi-Arch Builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
           name: docker buildx build and push
           command: |
             docker buildx build --platform linux/amd64,linux/arm64 \
-              -t jcolemorrison/hashicorp-demo-public-api:${CIRCLE_TAG} \
+              -t hashicorpdemoapp/public-api:${CIRCLE_TAG} \
               --push \
               .
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build-go:
     docker:
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.16.5
     environment:
       GO111MODULE: "on"
     working_directory: /go/src/github.com/hashicorp-demoapp/public-api
@@ -15,8 +15,11 @@ jobs:
           name: test application
           command: go test -v ./...
       - run:
-          name: build application (linux)
-          command: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/public-api
+          name: build application (linux amd64)
+          command: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/amd64/public-api
+      - run:
+          name: build application (linux arm64)
+          command: CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/arm6464/public-api
       - persist_to_workspace:
           root: /go/src/github.com/hashicorp-demoapp
           paths:
@@ -24,7 +27,7 @@ jobs:
   
   functional-tests:
     docker:
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.16.5
     steps:
       - checkout
       - setup_remote_docker
@@ -41,7 +44,7 @@ jobs:
 
   publish-docker-release:
     docker:
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.16.5
     environment:
       GO111MODULE: "on"
     working_directory: /go/src/github.com/hashicorp-demoapp/public-api
@@ -53,13 +56,21 @@ jobs:
           name: docker login
           command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
       - run:
-          name: docker build
+          name: docker buildx install
           command: |
-            docker build -t hashicorpdemoapp/public-api:${CIRCLE_TAG} .
+            docker buildx install
+            docker buildx create --use --name multi_arch_build
       - run:
-          name: docker push
+          name: docker buildx build and push
           command: |
-            docker push hashicorpdemoapp/public-api:${CIRCLE_TAG}
+            docker buildx build --platform linux/amd64,linux/arm64 \
+              -t jcolemorrison/hashicorp-demo-public-api:${CIRCLE_TAG} \
+              --push \
+              .
+      # - run:
+      #     name: docker push
+      #     command: |
+      #       docker push jcolemorrison/hashicorp-demo-public-api:${CIRCLE_TAG}
 
   publish-github-release:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build-go:
     docker:
-      - image: circleci/golang:1.16.5
+      - image: circleci/golang:1.13
     environment:
       GO111MODULE: "on"
     working_directory: /go/src/github.com/hashicorp-demoapp/public-api
@@ -19,7 +19,7 @@ jobs:
           command: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/amd64/public-api
       - run:
           name: build application (linux arm64)
-          command: CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/arm6464/public-api
+          command: CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/arm64/public-api
       - persist_to_workspace:
           root: /go/src/github.com/hashicorp-demoapp
           paths:
@@ -27,7 +27,7 @@ jobs:
   
   functional-tests:
     docker:
-      - image: circleci/golang:1.16.5
+      - image: circleci/golang:1.13
     steps:
       - checkout
       - setup_remote_docker
@@ -42,24 +42,45 @@ jobs:
           command: cd functional_test && shipyard test
 
 
+
   publish-docker-release:
     docker:
-      - image: circleci/golang:1.16.5
+      - image: circleci/golang:1.13
     environment:
       GO111MODULE: "on"
+      DOCKER_BUILDKIT: 1
+      BUILDX_PLATFORMS: linux/amd64,linux/arm64
     working_directory: /go/src/github.com/hashicorp-demoapp/public-api
     steps:
       - setup_remote_docker
       - attach_workspace:
           at: /go/src/github.com/hashicorp-demoapp
       - run:
+          name: install docker buildx
+          command: |
+            BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.4.2/buildx-v0.4.2.linux-amd64"
+
+            curl --output docker-buildx \
+              --silent --show-error --location --fail --retry 3 \
+              "$BUILDX_BINARY_URL"
+
+            mkdir -p ~/.docker/cli-plugins
+
+            mv docker-buildx ~/.docker/cli-plugins/
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+
+            docker buildx install
+
+            # Run binfmt
+            docker run --rm --privileged tonistiigi/binfmt:latest --install "$BUILDX_PLATFORMS"
+
+            docker context create multi_arch_build
+
+            # Create Builder
+            docker buildx create --use multi_arch_build
+      - run:
           name: docker login
           command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
-      - run:
-          name: docker buildx install
-          command: |
-            docker buildx install
-            docker buildx create --use --name multi_arch_build
       - run:
           name: docker buildx build and push
           command: |
@@ -67,10 +88,6 @@ jobs:
               -t jcolemorrison/hashicorp-demo-public-api:${CIRCLE_TAG} \
               --push \
               .
-      # - run:
-      #     name: docker push
-      #     command: |
-      #       docker push jcolemorrison/hashicorp-demo-public-api:${CIRCLE_TAG}
 
   publish-github-release:
     docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,23 @@
-FROM alpine:latest
+FROM alpine:latest as base
 
 RUN addgroup api && \
   adduser -D -G api api
 
 RUN mkdir /app
-COPY ./bin/public-api /app/public-api
+
+# Setup AMD64
+FROM base as image-amd64
+COPY ./bin/amd64/public-api /app/public-api
+RUN chmod +x /app/public-api
+
+# Setup ARM64
+FROM base as image-arm64
+COPY ./bin/arm64/public-api /app/public-api
+RUN chmod +x /app/public-api
+
+FROM image-${TARGETARCH}
+
+RUN echo "Running on $BUILDPLATFORM platform, building for $TARGETPLATFORM"
 
 USER api
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION=v0.0.4
-REPOSITORY=jcolemorrison/hashicorp-demo-public-api
+REPOSITORY=hashicorpdemoapp/public-api
 
 .PHONY: auth
 


### PR DESCRIPTION
Add multi-arch builds via `buildx` to both circleci process, makefile commands, and Dockerfile.