### PR TITLE
Fix healthcheck for product-api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=v0.0.8
+VERSION=v0.0.9
 REPOSITORY=hashicorpdemoapp/public-api
 
 .PHONY: auth

--- a/service/product.go
+++ b/service/product.go
@@ -20,7 +20,7 @@ func NewProductService(c *hashicups.Client) *ProductService {
 }
 
 func (s *ProductService) HealthCheck() bool {
-	resp, err := s.c.HTTPClient.Get(fmt.Sprintf("%s/health", s.c.HostURL))
+	resp, err := s.c.HTTPClient.Get(fmt.Sprintf("%s/health/readyz", s.c.HostURL))
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
The HashiCups `product-api` health check endpoint has changed from `/health` to `/health/livez` and `/health/readyz`.
- As defined in https://github.com/hashicorp-demoapp/product-api-go/blob/f7ef7a6288dd2bba69054b4ece7e751f359a3a30/main.go#LL101C16-L101C30

Furthermore, the old endpoint `/health` always reports unhealthy. Since this endpoint is deprecated, I'm not sure if that's a bug or a feature.
- As defined in https://github.com/hashicorp-demoapp/product-api-go/blob/f7ef7a6288dd2bba69054b4ece7e751f359a3a30/handlers/health.go#L30

This PR changes the healthcheck endpoint to the _Readiness_ one (`/health/readyz`).