### PR TITLE
adding errorRate to simulate HTTP 5xx service failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ build_linux_amd64:
 build_linux_arm64:
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o ./bin/arm64/public-api main.go
 
+build_darwin_arm64:
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o ./bin/arm64-darwin/public-api main.go
+
 build_docker: build_linux_amd64 build_linux_arm64
 	docker build -t ${REPOSITORY}:${VERSION} .
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=v0.0.9
+VERSION=v0.0.10
 REPOSITORY=hashicorpdemoapp/public-api
 
 .PHONY: auth

--- a/handlers/error_middleware.go
+++ b/handlers/error_middleware.go
@@ -1,0 +1,34 @@
+package handlers
+
+import (
+	"math/rand"
+	"net/http"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+// Middleware -
+type ErrorRateMiddleware struct {
+	errorRate int
+	log       hclog.Logger
+}
+
+// NewMiddleware -
+func NewErrorMiddleware(errorRate int, l hclog.Logger) *ErrorRateMiddleware {
+	return &ErrorRateMiddleware{errorRate, l}
+}
+
+// error rate middleware - returns an error based on environment variable
+func (emw *ErrorRateMiddleware) Middleware(next http.Handler) http.Handler {
+	randInt := rand.Intn(100)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if emw.errorRate > randInt {
+			emw.log.Error("Error rate triggered", "error", emw.errorRate)
+			http.Error(w, http.StatusText(500), http.StatusInternalServerError)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp-demoapp/go-hckit"
 	"github.com/hashicorp-demoapp/hashicups-client-go"
 	"github.com/hashicorp-demoapp/public-api/auth"
+	"github.com/hashicorp-demoapp/public-api/handlers"
 	"github.com/hashicorp-demoapp/public-api/models"
 	"github.com/hashicorp-demoapp/public-api/payments"
 	"github.com/hashicorp-demoapp/public-api/resolver"
@@ -33,6 +34,7 @@ var bindAddress = env.String("BIND_ADDRESS", false, ":8080", "Bind address for t
 var metricsAddress = env.String("METRICS_ADDRESS", false, ":9102", "Metrics address for the server")
 var productAddress = env.String("PRODUCT_API_URI", false, "http://localhost:9090", "Address for the product api")
 var paymentAddress = env.String("PAYMENT_API_URI", false, "http://localhost:18000", "Address for the payment api")
+var errorRate = env.Int("ERROR_RATE", false, 0, "Integer between 0 and 100 that represents how often the service should return 500 error code")
 
 func main() {
 	err := env.Parse()
@@ -84,6 +86,8 @@ func main() {
 	// Server.
 	r := mux.NewRouter()
 	r.Use(auth.Middleware(authn))
+	errorsMiddleware := handlers.NewErrorMiddleware(*errorRate, logger)
+	r.Use(errorsMiddleware.Middleware)
 	r.Use(hckit.TracingMiddleware)
 
 	// Enable CORS for all hosts


### PR DESCRIPTION
porting @im2nguyen 's errorRate from https://github.com/hashicorp-demoapp/product-api-go/pull/37